### PR TITLE
Update all docker-compose and Dockerfiles to use osg dockerhub 

### DIFF
--- a/Docker/osgflockingreport/Dockerfile
+++ b/Docker/osgflockingreport/Dockerfile
@@ -1,5 +1,5 @@
 # OSG base image for gracc-reporting
-FROM shreyb/gracc-osg-reports:2.0
+FROM opensciencegrid/gracc-osg-reports:2.0
 
 # Executable
 ENTRYPOINT ["osgflockingreport"]

--- a/Docker/osgflockingreport/docker-compose.yml
+++ b/Docker/osgflockingreport/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
         osgflockingreport:
-                image: "shreyb/gracc-osg-reports:osgflockingreport_${VERSIONRELEASE}"
+                image: "opensciencegrid/gracc-osg-reports:osgflockingreport_${VERSIONRELEASE}"
                 volumes:
                         - ${LOCALLOGDIR}:/tmp/log
                         - ${CONFIGDIR}:/tmp/gracc-osg-reports-config

--- a/Docker/osgmissingprojectsreport/Dockerfile
+++ b/Docker/osgmissingprojectsreport/Dockerfile
@@ -1,5 +1,5 @@
 # OSG base image for gracc-reporting
-FROM shreyb/gracc-osg-reports:2.0
+FROM opensciencegrid/gracc-osg-reports:2.0
 
 # Executable
 ENTRYPOINT ["osgmissingprojects"]

--- a/Docker/osgmissingprojectsreport/docker-compose.yml
+++ b/Docker/osgmissingprojectsreport/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
         osgmissingprojectsreport:
-                image: "shreyb/gracc-osg-reports:osgmissingprojectsreport_${VERSIONRELEASE}"
+                image: "opensciencegrid/gracc-osg-reports:osgmissingprojectsreport_${VERSIONRELEASE}"
                 volumes:
                         - ${LOCALLOGDIR}:/tmp/log
                         - ${CONFIGDIR}:/tmp/gracc-osg-reports-config

--- a/Docker/osgpersitereport/Dockerfile
+++ b/Docker/osgpersitereport/Dockerfile
@@ -1,5 +1,5 @@
 # OSG base image for gracc-reporting
-FROM shreyb/gracc-osg-reports:2.0
+FROM opensciencegrid/gracc-osg-reports:2.0
 
 # Executable
 ENTRYPOINT ["osgpersitereport"]

--- a/Docker/osgpersitereport/docker-compose.yml
+++ b/Docker/osgpersitereport/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
         osgpersitereport:
-                image: "shreyb/gracc-osg-reports:osgpersitereport_${VERSIONRELEASE}"
+                image: "opensciencegrid/gracc-osg-reports:osgpersitereport_${VERSIONRELEASE}"
                 volumes:
                         - ${LOCALLOGDIR}:/tmp/log
                         - ${CONFIGDIR}:/tmp/gracc-osg-reports-config

--- a/Docker/osgprobereport/Dockerfile
+++ b/Docker/osgprobereport/Dockerfile
@@ -1,5 +1,5 @@
 # OSG base image for gracc-reporting
-FROM shreyb/gracc-osg-reports:2.0
+FROM opensciencegrid/gracc-osg-reports:2.0
 
 # Executable
 ENTRYPOINT ["osgprobereport"]

--- a/Docker/osgprobereport/docker-compose.yml
+++ b/Docker/osgprobereport/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
         osgprobereport:
-                image: "shreyb/gracc-osg-reports:osgprobereport_${VERSIONRELEASE}"
+                image: "opensciencegrid/gracc-osg-reports:osgprobereport_${VERSIONRELEASE}"
                 volumes:
                         - state:/tmp/log:Z
                         - ${CONFIGDIR}:/tmp/gracc-osg-reports-config

--- a/Docker/osgprojectreport/Dockerfile
+++ b/Docker/osgprojectreport/Dockerfile
@@ -1,5 +1,5 @@
 # OSG base image for gracc-reporting
-FROM shreyb/gracc-osg-reports:2.0
+FROM opensciencegrid/gracc-osg-reports:2.0
 
 # Executable
 ENTRYPOINT ["osgprojectreport"]

--- a/Docker/osgprojectreport/docker-compose.yml
+++ b/Docker/osgprojectreport/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
         osgprojectreport:
-                image: "shreyb/gracc-osg-reports:osgprojectreport_${VERSIONRELEASE}"
+                image: "opensciencegrid/gracc-osg-reports:osgprojectreport_${VERSIONRELEASE}"
                 volumes:
                         - ${LOCALLOGDIR}:/tmp/log
                         - ${CONFIGDIR}:/tmp/gracc-osg-reports-config

--- a/Docker/osgtopoppusagereport/Dockerfile
+++ b/Docker/osgtopoppusagereport/Dockerfile
@@ -1,5 +1,5 @@
 # OSG base image for gracc-reporting
-FROM shreyb/gracc-osg-reports:2.0
+FROM opensciencegrid/gracc-osg-reports:2.0
 
 # Executable
 ENTRYPOINT ["osgtopoppusagereport"]

--- a/Docker/osgtopoppusagereport/docker-compose.yml
+++ b/Docker/osgtopoppusagereport/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
         osgtopoppusagereport:
-                image: "shreyb/gracc-osg-reports:osgtopoppusagereport_${VERSIONRELEASE}"
+                image: "opensciencegrid/gracc-osg-reports:osgtopoppusagereport_${VERSIONRELEASE}"
                 volumes:
                         - ${LOCALLOGDIR}:/tmp/log
                         - ${CONFIGDIR}:/tmp/gracc-osg-reports-config

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM shreyb/gracc-reporting:2.0 
+FROM opensciencegrid/gracc-reporting:2.0 
 ARG version
 
 RUN apk update \

--- a/packaging/create_docker_image.sh
+++ b/packaging/create_docker_image.sh
@@ -26,7 +26,7 @@ if [[ "x$DOCKER" == "x" ]] ; then
 	exit 1
 fi
 
-DOCKERIMAGEPREFIX="shreyb/gracc-osg-reports"
+DOCKERIMAGEPREFIX="opensciencegrid/gracc-osg-reports"
 DOCKERIMAGE="${DOCKERIMAGEPREFIX}:${VERSION}"
 echo "Will build image $DOCKERIMAGE"
 


### PR DESCRIPTION
Before, the docker images were getting pulled from my personal dockerhub.  Now it's on the official osg dockerhub at opensciencegrid/gracc-osg-reports